### PR TITLE
Add stored procedure support to DBGear core

### DIFF
--- a/packages/dbgear/dbgear/dbio/procedure.py
+++ b/packages/dbgear/dbgear/dbio/procedure.py
@@ -1,0 +1,34 @@
+"""Database stored procedure operations."""
+
+from . import engine
+from .templates.mysql import template_engine
+from ..models.procedure import Procedure
+
+
+def is_exist(conn, env: str, procedure: Procedure):
+    """Check if stored procedure exists"""
+    sql = template_engine.render('mysql_check_procedure_exists')
+    result = engine.select_one(conn, sql, {
+        'env': env, 
+        'procedure_name': procedure.procedure_name,
+        'routine_type': 'FUNCTION' if procedure.is_function else 'PROCEDURE'
+    })
+    return result is not None
+
+
+def drop(conn, env: str, procedure: Procedure):
+    """Drop stored procedure or function"""
+    if procedure.is_function:
+        sql = template_engine.render('mysql_drop_function', env=env, procedure_name=procedure.procedure_name)
+    else:
+        sql = template_engine.render('mysql_drop_procedure', env=env, procedure_name=procedure.procedure_name)
+    engine.execute(conn, sql)
+
+
+def create(conn, env: str, procedure: Procedure):
+    """Create stored procedure or function"""
+    if procedure.is_function:
+        sql = template_engine.render('mysql_create_function', env=env, procedure=procedure)
+    else:
+        sql = template_engine.render('mysql_create_procedure', env=env, procedure=procedure)
+    engine.execute(conn, sql)

--- a/packages/dbgear/dbgear/models/procedure.py
+++ b/packages/dbgear/dbgear/models/procedure.py
@@ -1,0 +1,70 @@
+import pydantic
+
+from .base import BaseSchema
+from .notes import Note
+from .notes import NoteManager
+
+
+class ProcedureParameter(BaseSchema):
+    """Stored procedure parameter definition"""
+    parameter_name: str
+    parameter_type: str  # IN | OUT | INOUT
+    data_type: str  # VARCHAR(255), INT, etc.
+    default_value: str | None = None
+
+
+class Procedure(BaseSchema):
+    """Stored procedure definition"""
+    procedure_name: str = pydantic.Field(exclude=True)
+    display_name: str
+    parameters: list[ProcedureParameter] = pydantic.Field(default_factory=list)
+    return_type: str | None = None  # For functions (NULL for procedures)
+    body: str  # SQL procedure body
+    language: str = "SQL"  # SQL, PLPGSQL for future database support
+    deterministic: bool = False
+    reads_sql_data: bool = True
+    modifies_sql_data: bool = False
+    security_type: str = "DEFINER"  # DEFINER | INVOKER
+    notes_: list[Note] = pydantic.Field(default_factory=list, alias='notes')
+
+    @property
+    def notes(self) -> NoteManager:
+        return NoteManager(self.notes_)
+
+    @property
+    def is_function(self) -> bool:
+        """Returns True if this is a function (has return type), False if procedure"""
+        return self.return_type is not None
+
+
+class ProcedureManager:
+    """Manager for stored procedure collections"""
+
+    def __init__(self, procedures: dict[str, Procedure]):
+        self.procedures = procedures
+
+    def __getitem__(self, procedure_name: str) -> Procedure:
+        return self.procedures[procedure_name]
+
+    def __iter__(self):
+        yield from self.procedures.values()
+
+    def __len__(self) -> int:
+        return len(self.procedures)
+
+    def __contains__(self, procedure_name: str) -> bool:
+        return procedure_name in self.procedures
+
+    def append(self, procedure: Procedure) -> None:
+        if procedure.procedure_name in self.procedures:
+            raise ValueError(f"Procedure '{procedure.procedure_name}' already exists")
+        self.procedures[procedure.procedure_name] = procedure
+
+    def remove(self, procedure_name: str) -> None:
+        if procedure_name not in self.procedures:
+            raise KeyError(f"Procedure '{procedure_name}' does not exist")
+        del self.procedures[procedure_name]
+
+    def add(self, procedure: Procedure) -> None:
+        """Alias for append for consistency with other managers"""
+        self.append(procedure)

--- a/packages/dbgear/dbgear/models/schema.py
+++ b/packages/dbgear/dbgear/models/schema.py
@@ -11,6 +11,8 @@ from .view import View
 from .view import ViewManager
 from .trigger import Trigger
 from .trigger import TriggerManager
+from .procedure import Procedure
+from .procedure import ProcedureManager
 from .notes import Note
 from .notes import NoteManager
 from ..utils.populate import auto_populate_from_keys
@@ -21,6 +23,7 @@ class Schema(BaseSchema):
     tables_: dict[str, Table] = pydantic.Field(default_factory=dict, alias='tables')
     views_: dict[str, View] = pydantic.Field(default_factory=dict, alias='views')
     triggers_: dict[str, Trigger] = pydantic.Field(default_factory=dict, alias='triggers')
+    procedures_: dict[str, Procedure] = pydantic.Field(default_factory=dict, alias='procedures')
     notes_: list[Note] = pydantic.Field(default_factory=list, alias='notes')
 
     @property
@@ -36,6 +39,10 @@ class Schema(BaseSchema):
         return TriggerManager(self.triggers_)
 
     @property
+    def procedures(self) -> ProcedureManager:
+        return ProcedureManager(self.procedures_)
+
+    @property
     def notes(self) -> NoteManager:
         return NoteManager(self.notes_)
 
@@ -43,6 +50,7 @@ class Schema(BaseSchema):
         self.tables_.update(other.tables_)
         self.views_.update(other.views_)
         self.triggers_.update(other.triggers_)
+        self.procedures_.update(other.procedures_)
         self.notes_.extend(other.notes_)
 
 
@@ -65,6 +73,8 @@ class SchemaManager(BaseSchema):
             'schemas.$1.views.$2.view_name': '$2',
             'schemas.$1.triggers.$2.instance': '$1',
             'schemas.$1.triggers.$2.trigger_name': '$2',
+            'schemas.$1.procedures.$2.instance': '$1',
+            'schemas.$1.procedures.$2.procedure_name': '$2',
         })
         return cls(**populated_data)
 

--- a/packages/dbgear/dbgear/operations.py
+++ b/packages/dbgear/dbgear/operations.py
@@ -6,6 +6,7 @@ from .dbio import database
 from .dbio import table
 from .dbio import view
 from .dbio import trigger
+from .dbio import procedure
 
 from .models.project import Project
 from .models.mapping import Mapping
@@ -85,6 +86,19 @@ class Operation:
                 logger.info(f'drop & create trigger {map.instance_name}.{tr.trigger_name}')
                 trigger.drop(self.conn, map.instance_name, tr)
                 trigger.create(self.conn, map.instance_name, tr)
+
+        for proc in schema.procedures:
+            if not all and target != proc.procedure_name:
+                continue
+            # プロシージャが存在しない場合は作成する。
+            if not procedure.is_exist(self.conn, map.instance_name, proc):
+                logger.info(f'procedure {map.instance_name}.{proc.procedure_name} was created.')
+                procedure.create(self.conn, map.instance_name, proc)
+            else:
+                # プロシージャの再作成
+                logger.info(f'drop & create procedure {map.instance_name}.{proc.procedure_name}')
+                procedure.drop(self.conn, map.instance_name, proc)
+                procedure.create(self.conn, map.instance_name, proc)
 
     def insert_data(self, map: Mapping, schema: Schema, all: bool, target: str):
         # データ投入

--- a/packages/dbgear/tests/test_procedure.py
+++ b/packages/dbgear/tests/test_procedure.py
@@ -1,0 +1,130 @@
+import unittest
+from dbgear.models.procedure import Procedure, ProcedureParameter, ProcedureManager
+
+
+class TestProcedure(unittest.TestCase):
+
+    def test_procedure_creation(self):
+        """Test basic procedure creation and properties"""
+        params = [
+            ProcedureParameter(
+                parameter_name="user_id",
+                parameter_type="IN",
+                data_type="INT"
+            ),
+            ProcedureParameter(
+                parameter_name="result",
+                parameter_type="OUT",
+                data_type="VARCHAR(255)"
+            )
+        ]
+        
+        procedure = Procedure(
+            procedure_name="get_user_info",
+            display_name="Get User Information",
+            parameters=params,
+            body="SELECT name INTO result FROM users WHERE id = user_id;",
+            deterministic=True,
+            reads_sql_data=True,
+            modifies_sql_data=False
+        )
+        
+        self.assertEqual(procedure.procedure_name, "get_user_info")
+        self.assertEqual(procedure.display_name, "Get User Information")
+        self.assertEqual(len(procedure.parameters), 2)
+        self.assertFalse(procedure.is_function)
+        self.assertTrue(procedure.deterministic)
+        self.assertTrue(procedure.reads_sql_data)
+        self.assertFalse(procedure.modifies_sql_data)
+        self.assertEqual(procedure.security_type, "DEFINER")
+
+    def test_function_creation(self):
+        """Test function creation (procedure with return type)"""
+        params = [
+            ProcedureParameter(
+                parameter_name="user_id",
+                parameter_type="IN",
+                data_type="INT"
+            )
+        ]
+        
+        function = Procedure(
+            procedure_name="get_user_name",
+            display_name="Get User Name Function",
+            parameters=params,
+            return_type="VARCHAR(255)",
+            body="RETURN (SELECT name FROM users WHERE id = user_id);",
+            deterministic=True
+        )
+        
+        self.assertTrue(function.is_function)
+        self.assertEqual(function.return_type, "VARCHAR(255)")
+
+    def test_procedure_manager(self):
+        """Test ProcedureManager operations"""
+        procedure1 = Procedure(
+            procedure_name="proc1",
+            display_name="Procedure 1",
+            body="SELECT 1;"
+        )
+        
+        procedure2 = Procedure(
+            procedure_name="proc2",
+            display_name="Procedure 2",
+            body="SELECT 2;"
+        )
+        
+        # Test manager initialization and operations
+        procedures_dict = {}
+        manager = ProcedureManager(procedures_dict)
+        
+        # Test append
+        manager.append(procedure1)
+        manager.add(procedure2)  # Test alias
+        
+        self.assertEqual(len(manager), 2)
+        self.assertIn("proc1", manager)
+        self.assertIn("proc2", manager)
+        
+        # Test getitem
+        self.assertEqual(manager["proc1"].display_name, "Procedure 1")
+        
+        # Test iteration
+        procedure_names = [proc.procedure_name for proc in manager]
+        self.assertIn("proc1", procedure_names)
+        self.assertIn("proc2", procedure_names)
+        
+        # Test remove
+        manager.remove("proc1")
+        self.assertEqual(len(manager), 1)
+        self.assertNotIn("proc1", manager)
+        
+        # Test error cases
+        with self.assertRaises(ValueError):
+            manager.append(procedure2)  # Already exists
+            
+        with self.assertRaises(KeyError):
+            manager.remove("nonexistent")  # Doesn't exist
+
+    def test_parameter_with_default(self):
+        """Test procedure parameter with default value"""
+        param = ProcedureParameter(
+            parameter_name="limit_count",
+            parameter_type="IN",
+            data_type="INT",
+            default_value="10"
+        )
+        
+        procedure = Procedure(
+            procedure_name="get_recent_users",
+            display_name="Get Recent Users",
+            parameters=[param],
+            body="SELECT * FROM users ORDER BY created_at DESC LIMIT limit_count;",
+            reads_sql_data=True
+        )
+        
+        self.assertEqual(procedure.parameters[0].default_value, "10")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add Procedure and ProcedureParameter models with full CRUD operations
- Add database operations for CREATE/DROP PROCEDURE and FUNCTION
- Add MySQL SQL templates with DELIMITER handling and parameter support
- Integrate procedures into schema management and CLI operations
- Add comprehensive unit tests for procedure functionality
- Support both stored procedures and functions with return types

🤖 Generated with [Claude Code](https://claude.ai/code)