### PR TITLE
Fix AttributeError in index_card function

### DIFF
--- a/packages/dbgear-editor/dbgear_editor/ui/tables.py
+++ b/packages/dbgear-editor/dbgear_editor/ui/tables.py
@@ -156,7 +156,7 @@ def index_card(index):
         ),
         Div(
             Span("Columns: ", cls="font-medium text-gray-700"),
-            Span(", ".join([col.column_name for col in index.columns]), cls="text-gray-900"),
+            Span(", ".join(index.columns), cls="text-gray-900"),
             cls="mt-2"
         ),
         *([

--- a/packages/dbgear-editor/pyproject.toml
+++ b/packages/dbgear-editor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbgear-editor"
-version = "0.1.0"
+version = "0.2.0"
 description = "FastHTML-based web editor for DBGear schema and data management"
 authors = [
     {name = "tamuto", email = "mutomob@gmail.com"}


### PR DESCRIPTION
index.columns contains strings, not column objects with .column_name attribute. Changed to directly join the string list instead of accessing .column_name.

🤖 Generated with [Claude Code](https://claude.ai/code)