### PR TITLE
Replace mermaid.js with cytoscape.js for interactive ER diagrams

### DIFF
--- a/packages/dbgear-editor/dbgear_editor/components/sidebar.py
+++ b/packages/dbgear-editor/dbgear_editor/components/sidebar.py
@@ -106,7 +106,7 @@ def schema_section(schema_name: str, schema, schema_tables: dict, schema_views: 
                         Span("Tables", cls="text-xs font-medium text-gray-700"),
                         cls="flex items-center px-3 py-1"
                     ),
-                    *[table_item(table_name, table, schema_name, current_path) for table_name, table in schema_tables.items()],
+                    *[table_item(table_name, table, schema_name, current_path) for table_name, table in sorted(schema_tables.items())],
                     cls="mb-2"
                 )
             ] if schema_tables else []),
@@ -119,7 +119,7 @@ def schema_section(schema_name: str, schema, schema_tables: dict, schema_views: 
                         Span("Views", cls="text-xs font-medium text-gray-700"),
                         cls="flex items-center px-3 py-1"
                     ),
-                    *[view_item(view_name, view, schema_name, current_path) for view_name, view in schema_views.items()],
+                    *[view_item(view_name, view, schema_name, current_path) for view_name, view in sorted(schema_views.items())],
                     cls="mb-2"
                 )
             ] if schema_views else []),
@@ -132,7 +132,7 @@ def schema_section(schema_name: str, schema, schema_tables: dict, schema_views: 
                         Span("Procedures", cls="text-xs font-medium text-gray-700"),
                         cls="flex items-center px-3 py-1"
                     ),
-                    *[procedure_item(procedure_name, procedure, schema_name, current_path) for procedure_name, procedure in schema_procedures.items()],
+                    *[procedure_item(procedure_name, procedure, schema_name, current_path) for procedure_name, procedure in sorted(schema_procedures.items())],
                     cls="mb-2"
                 )
             ] if schema_procedures else []),
@@ -145,7 +145,7 @@ def schema_section(schema_name: str, schema, schema_tables: dict, schema_views: 
                         Span("Triggers", cls="text-xs font-medium text-gray-700"),
                         cls="flex items-center px-3 py-1"
                     ),
-                    *[trigger_item(trigger_name, trigger, schema_name, current_path) for trigger_name, trigger in schema_triggers.items()],
+                    *[trigger_item(trigger_name, trigger, schema_name, current_path) for trigger_name, trigger in sorted(schema_triggers.items())],
                     cls="mb-2"
                 )
             ] if schema_triggers else []),

--- a/packages/dbgear-editor/dbgear_editor/layout.py
+++ b/packages/dbgear-editor/dbgear_editor/layout.py
@@ -23,6 +23,8 @@ def layout(content, title="DBGear Editor", current_path=""):
     """
     return (
         Title(title),
+        # Add Cytoscape.js CDN
+        Script(src="https://unpkg.com/cytoscape@3.30.3/dist/cytoscape.min.js"),
         # Add JavaScript for dropdown and collapsible functionality
         Script("""
             document.addEventListener('DOMContentLoaded', function() {

--- a/packages/dbgear-editor/dbgear_editor/ui/common.py
+++ b/packages/dbgear-editor/dbgear_editor/ui/common.py
@@ -48,7 +48,8 @@ def entity_grid(entities: dict, schema_name: str, entity_type: str, icon: str, c
         return Div()
 
     entity_cards = []
-    for entity_name, entity in entities.items():
+    # Sort entities by name for consistent display
+    for entity_name, entity in sorted(entities.items()):
         # Get entity-specific info
         info_text = get_entity_info_text(entity, entity_type)
 

--- a/packages/dbgear-editor/dbgear_editor/ui/tables.py
+++ b/packages/dbgear-editor/dbgear_editor/ui/tables.py
@@ -14,7 +14,8 @@ def table_grid(tables: dict, schema_name: str):
         return Div()
 
     table_cards = []
-    for table_name, table in tables.items():
+    # Sort tables by name for consistent display
+    for table_name, table in sorted(tables.items()):
         column_count = len(table.columns) if hasattr(table, 'columns') else 0
 
         table_cards.append(

--- a/packages/dbgear-editor/pyproject.toml
+++ b/packages/dbgear-editor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbgear-editor"
-version = "0.2.0"
+version = "0.3.0"
 description = "FastHTML-based web editor for DBGear schema and data management"
 authors = [
     {name = "tamuto", email = "mutomob@gmail.com"}


### PR DESCRIPTION
- Migrate from static Mermaid diagrams to interactive Cytoscape.js visualizations
- Add cytoscape.js CDN integration in layout.py
- Convert ER diagram generation from Mermaid syntax to JSON format
- Implement interactive features: zoom, pan, node clicking for navigation
- Fix click navigation URLs to use correct table detail routes
- Add visual styling for different relationship types and central nodes
- Sort entity lists for consistent UI display
- Update version to 0.3.0

🤖 Generated with [Claude Code](https://claude.ai/code)