### PR TITLE
Replace DatabaseInfo.settings with TenantConfig.data_args for flexibl…

### DIFF
--- a/packages/dbgear/dbgear/models/environ.py
+++ b/packages/dbgear/dbgear/models/environ.py
@@ -79,7 +79,7 @@ class Environ(BaseSchema):
             if map.deploy:
                 yield map
         if self.tenant is not None:
-            yield from self.tenant.materialize()
+            yield from self.tenant.materialize(self.settings)
 
 
 class EnvironManager:

--- a/packages/dbgear/dbgear/models/mapping.py
+++ b/packages/dbgear/dbgear/models/mapping.py
@@ -25,8 +25,7 @@ class Mapping(BaseSchema):
     charset: str | None = None      # e.g., utf8mb4, latin1
     collation: str | None = None    # e.g., utf8mb4_unicode_ci, utf8mb4_ja_0900_as_cs
 
-    # Tenant-specific settings (populated during materialize)
-    settings: dict[str, str] = pydantic.Field(default_factory=dict, exclude=True)
+
 
     @classmethod
     def _directory(cls, folder: str, environ: str, name: str) -> str:

--- a/packages/dbgear/dbgear/models/tenant.py
+++ b/packages/dbgear/dbgear/models/tenant.py
@@ -3,23 +3,26 @@ import yaml
 import os
 import importlib
 
+from typing import Any
+
 from .base import BaseSchema
 from .mapping import Mapping
 from .exceptions import DBGearEntityExistsError
 from .exceptions import DBGearEntityNotFoundError
 from ..utils.populate import auto_populate_from_keys
+from ..utils.variable import expand_dict
 
 
 class DatabaseInfo(BaseSchema):
     database: str
     description: str | None = None
     active: bool = True
-    settings: dict[str, str] = pydantic.Field(default_factory=dict)
 
 
 class TenantConfig(BaseSchema):
     name: str = pydantic.Field(exclude=True)
     ref: str
+    data_args: dict[str, Any] = pydantic.Field(default_factory=dict)
 
     # tenant variables
     databases: str | list[DatabaseInfo]
@@ -84,15 +87,15 @@ class TenantRegistry(BaseSchema):
             raise DBGearEntityNotFoundError(f'Tenant {name} does not exist')
         del self.tenants[name]
 
-    def materialize(self):
+    def materialize(self, settings: dict[str, str] = None):
         for tenant in self.tenants.values():
             map = Mapping.load(self.folder, self.name, tenant.ref)
+            expanded_args = expand_dict(tenant.data_args, settings) if settings and tenant.data_args else tenant.data_args
 
             if type(tenant.databases) is str:
                 module = importlib.import_module(tenant.databases)
-                method_name = "retrieve"
-                method = getattr(module, method_name)
-                for tenant_map in method(map):
+                method = getattr(module, "retrieve")
+                for tenant_map in method(map, **expanded_args):
                     yield tenant_map
             else:
                 for database in tenant.databases:
@@ -100,5 +103,4 @@ class TenantRegistry(BaseSchema):
                         continue
                     clone = map.model_copy(deep=True)
                     clone.tenant_name = database.database
-                    clone.settings = database.settings.copy()
                     yield clone

--- a/packages/dbgear/dbgear/operations.py
+++ b/packages/dbgear/dbgear/operations.py
@@ -178,7 +178,7 @@ class Operation:
             # 処理済みとしてマーク
             processed_tables.add(dm.table_name)
 
-            base_settings = {**self.environ.settings, **map.settings}
+            base_settings = {**self.environ.settings}
             for ds in dm.get_datasources(base_settings):
                 self._log(f'insert {ds.filename} to {map.instance_name}.{tbl.table_name}')
                 ds.load()
@@ -275,7 +275,7 @@ class Operation:
             tbl = schema.tables[table_name]
             dm = map.datamodel(schema_name, table_name)
             if dm is not None:
-                base_settings = {**self.environ.settings, **map.settings}
+                base_settings = {**self.environ.settings}
                 for ds in dm.get_datasources(base_settings):
                     self._log(f'insert {ds.filename} to {map.instance_name}.{tbl.table_name}')
                     ds.load()

--- a/packages/dbgear/pyproject.toml
+++ b/packages/dbgear/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbgear"
-version = "0.42.2"
+version = "0.43.0"
 description = "Database management tools for initial data management"
 authors = ["tamuto <tamuto@infodb.jp>"]
 readme = "README.md"

--- a/packages/dbgear/tests/models/test_tenant.py
+++ b/packages/dbgear/tests/models/test_tenant.py
@@ -108,19 +108,18 @@ class TestTenant(unittest.TestCase):
         docker_tenant = loaded_registry['docker']
         self.assertEqual(len(docker_tenant.databases), 2)
 
-    def test_database_info_settings(self):
-        """Test DatabaseInfo with settings for variable expansion"""
-        # Create tenant with settings
+    def test_tenant_config_data_args(self):
+        """Test TenantConfig with data_args for variable expansion"""
         db_info = DatabaseInfo(
             database='tenant_db',
-            description='Tenant with settings',
+            description='Tenant with data_args',
             active=True,
-            settings={'app_name': 'TenantApp', 'base_url': 'https://tenant.example.com'}
         )
 
         tenant_config = TenantConfig(
-            name='with_settings',
+            name='with_args',
             ref='base',
+            data_args={'app_name': '$app', 'base_url': 'https://$host/api'},
             databases=[db_info]
         )
 
@@ -134,14 +133,18 @@ class TestTenant(unittest.TestCase):
 
         # Load and verify
         loaded_registry = TenantRegistry.load(self.temp_dir, 'test_env')
-        loaded_db = loaded_registry['with_settings'].databases[0]
-        self.assertEqual(loaded_db.settings['app_name'], 'TenantApp')
-        self.assertEqual(loaded_db.settings['base_url'], 'https://tenant.example.com')
+        loaded_tenant = loaded_registry['with_args']
+        self.assertEqual(loaded_tenant.data_args['app_name'], '$app')
+        self.assertEqual(loaded_tenant.data_args['base_url'], 'https://$host/api')
 
-    def test_database_info_default_empty_settings(self):
-        """Test DatabaseInfo defaults to empty settings"""
-        db_info = DatabaseInfo(database='simple_db')
-        self.assertEqual(db_info.settings, {})
+    def test_tenant_config_default_empty_data_args(self):
+        """Test TenantConfig defaults to empty data_args"""
+        tenant_config = TenantConfig(
+            name='simple',
+            ref='base',
+            databases='some.module.path'
+        )
+        self.assertEqual(tenant_config.data_args, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…e tenant variable expansion

Move tenant-specific settings from DatabaseInfo to TenantConfig as data_args with variable expansion support. This enables passing kwargs to retrieve() when databases is a Python module string, and simplifies settings to environ-level only.